### PR TITLE
Improve Clarity of syncHandler Comment in Sample Controller

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -250,8 +250,8 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 }
 
 // syncHandler compares the actual state with the desired, and attempts to
-// converge the two. It then updates the Status block of the Foo resource
-// with the current status of the resource.
+// align the first with the latter. It then updates the Status block of the
+// Foo resource with the current status of the resource.
 func (c *Controller) syncHandler(ctx context.Context, key string) error {
 	// Convert the namespace/name string into a distinct namespace and name
 	logger := klog.LoggerWithValues(klog.FromContext(ctx), "resourceName", key)


### PR DESCRIPTION
## Overview
This PR proposes a minor yet significant update to the comment of the `syncHandler` function in the sample-controller. The aim is to enhance clarity and reduce potential ambiguity for developers who might not be deeply familiar with the Kubernetes controller pattern.

## Changes
The original comment used the term "converge" to describe the process of aligning the actual state of a resource with its desired state. However, this term can be somewhat ambiguous, especially for newcomers or those not intimately familiar with Kubernetes' declarative approach. The proposed change in this PR replaces "converge" with a more explicit phrase to clarify the intended operation of the `syncHandler` function.

### Original Comment
```go
// syncHandler compares the actual state with the desired, and attempts to
// converge the two. It then updates the Status block of the Foo resource
// with the current status of the resource.
```

### Updated Comment
```go
// syncHandler compares the actual state with the desired, and attempts to
// align the first to the latter. It then updates the Status block of the
// Foo resource with the current status of the resource.
```

## Rationale

The adjustment in the comment aims to make the description more accessible and straightforward, particularly for those who might be learning about Kubernetes controllers for the first time. This change is in line with best practices for code documentation, where clarity and precision are crucial for effective communication and understanding.

## Impact

The change is limited to the comment and does not affect the functionality of the code. It is intended purely for educational and clarity purposes, enhancing the overall quality of the documentation in the sample-controller.